### PR TITLE
Include libraries as package-data in pyproject and add packages.find

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ include-package-data = true  # Important: Enables inclusion of non-code files
 where = ["."]
 
 [tool.setuptools.package-data]
-"*" = ["*.jar"]
+"pydbzengine" = ["debezium/libs/*.jar", "config/*"]
 
 [project]
 name = "pydbzengine"


### PR DESCRIPTION
As mentioned in #26, the current pyproject does not include the data directories, so they were missing when the package was installed.