### PR TITLE
feat(helper): add helper to stop engine automatically after Debezium snapshot completion

### DIFF
--- a/pydbzengine/examples/dlt_consuming.py
+++ b/pydbzengine/examples/dlt_consuming.py
@@ -129,7 +129,7 @@ def main():
 
     # Run the Debezium engine asynchronously with a timeout.  This allows the example
     # to run for a limited time and then terminate automatically.
-    Utils.run_engine_async(engine=engine, timeout_sec=60)
+    Utils.run_engine_until_snapshot(engine)
     # engine.run()  # This would be used for synchronous execution (without timeout)
 
     # ================ PRINT THE CONSUMED DATA FROM DUCKDB ===========================

--- a/pydbzengine/helper.py
+++ b/pydbzengine/helper.py
@@ -54,3 +54,48 @@ class Utils:
             # **Crucially important:** Cancel the alarm.  This prevents the timeout
             # from triggering again later if the main thread continues to run.
             signal.alarm(0)  # 0 means cancel the alarm.
+
+    @staticmethod
+    def run_engine_until_snapshot(engine, poll_interval_sec=1):
+        """
+        Run Debezium engine and automatically stop when the initial
+        snapshot is completed (snapshot.mode=initial_only).
+
+        The engine runs in a background thread while this function
+        periodically checks for the snapshot completion log message.
+        """
+
+        import threading
+        import time
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        def _run():
+            engine.run()
+
+        thread = threading.Thread(target=_run, daemon=True)
+        thread.start()
+
+        try:
+            while thread.is_alive():
+
+                # read logs emitted by debezium
+                log_output = logging.root.handlers
+
+                for handler in log_output:
+                    if hasattr(handler, "stream"):
+                        try:
+                            stream_value = handler.stream.getvalue()
+                        except Exception:
+                            continue
+
+                        if "Snapshot completed" in stream_value:
+                            logger.info("Snapshot completion detected. Closing engine.")
+                            engine.close()
+                            return
+
+                time.sleep(poll_interval_sec)
+
+        finally:
+            thread.join()


### PR DESCRIPTION
Currently the engine can be executed using:

```bash
engine.run()
Utils.run_engine_async(engine, timeout_sec)
```

When snapshot.mode=initial_only, Debezium completes the initial snapshot but the engine continues running afterwards. Because of this, the example currently relies on a fixed timeout to terminate the process.

This change adds a helper method:

Utils.run_engine_until_snapshot(engine)

The helper runs the engine in a background thread, monitors the emitted logs, and closes the engine once the snapshot completion message is detected.

The example dlt_consuming.py was updated to demonstrate usage of this helper instead of relying on a timeout.

Closes #27